### PR TITLE
Redesign announcement search

### DIFF
--- a/core/components/Card/Small.tsx
+++ b/core/components/Card/Small.tsx
@@ -30,7 +30,11 @@ export const CardSmall = ({
   <div>
     <MaterialCard
       onClick={() => onClick()}
-      style={{ height: '201px', width: '403px' }}
+      style={{
+        height: '201px',
+        width: '403px',
+        boxShadow: '10px -3px 15px rgba(0, 0, 0, 0.10), 4px -2px 6px rgba(0, 0, 0, 0.05)'
+      }}
       className={`${className} grid grid-cols-4 p-4 gap-4`}>
       <div style={{ height: '80px' }} className="col-span-1">
         {srcImg !== '-' && (

--- a/features/Academic-Industry/components/AnnouncementDetail.tsx
+++ b/features/Academic-Industry/components/AnnouncementDetail.tsx
@@ -26,7 +26,12 @@ export const AnnouncementDetail = ({ data }: AnnouncementDetailProps) => {
   return (
     <div className="w-full ml-5 mr-auto md:w-5/12">
       <div>
-        <MaterialCard style={{ height: '1100px', width: '562px' }}>
+        <MaterialCard
+          style={{
+            height: '1100px',
+            width: '562px',
+            boxShadow: '10px -3px 15px rgba(0, 0, 0, 0.10), 4px -2px 6px rgba(0, 0, 0, 0.05)'
+          }}>
           <div className="flex items-end justify-end w-full h-40 rounded-none bg-grey-100">
             {data?.picture !== '-' && (
               <img

--- a/features/Academic-Industry/pages/announcement-search.tsx
+++ b/features/Academic-Industry/pages/announcement-search.tsx
@@ -28,9 +28,9 @@ const AnnouncementSearch = () => {
     <Observer>
       {() => (
         <div>
-          <div className="flex justify-center w-full h-full pt-16 pb-3 bg-grey4">
+          <div className="container grid max-w-screen-lg grid-flow-row mx-auto mt-20 bg-white shadow-lg rounded-lg font-prompt px-10">
             <div className="w-full max-w-screen-lg my-6">
-              <div className="w-full h-8 max-w-screen-lg bg-grey-100">
+              <div className="p-2 w-full bg-white border-opacity-50 rounded border-DEFAULT border-secondary2">
                 <Search
                   onChange={(event) => {
                     if (typeof event.target.value === 'string') {
@@ -41,8 +41,8 @@ const AnnouncementSearch = () => {
                 />
               </div>
               <div className="flex flex-row justify-between pt-6">
-                <div className="w-3/12 pr-5">
-                  <FormControl className="w-full font-prompt bg-grey-100">
+                <div className="w-3/12">
+                  <FormControl className="w-full font-prompt" variant="outlined">
                     <InputLabel htmlFor="trinity-select">ประเภทของงาน</InputLabel>
                     <Select
                       id="trinity-select"
@@ -60,8 +60,8 @@ const AnnouncementSearch = () => {
                     </Select>
                   </FormControl>
                 </div>
-                <div className="w-3/12 pl-6 pr-5">
-                  <FormControl className="w-full font-prompt bg-grey-100">
+                <div className="w-3/12 pl-5">
+                  <FormControl className="w-full font-prompt" variant="outlined">
                     <InputLabel htmlFor="trinity-select">ประเภทของประกาศ</InputLabel>
                     <Select
                       id="trinity-select"
@@ -79,8 +79,8 @@ const AnnouncementSearch = () => {
                     </Select>
                   </FormControl>
                 </div>
-                <div className="w-3/12 pl-6 pr-5">
-                  <FormControl className="w-full font-prompt bg-grey-100">
+                <div className="w-3/12 pl-5">
+                  <FormControl className="w-full font-prompt" variant="outlined">
                     <InputLabel htmlFor="trinity-select">ประเภทของษริษัท</InputLabel>
                     <Select
                       id="trinity-select"
@@ -143,7 +143,6 @@ const AnnouncementSearch = () => {
               </div>
             </div>
           </div>
-          <div className="w-full h-1 bg-secondary1" />
           <div className="flex justify-center w-full h-full pb-10">
             <div className="-mt-24">
               <div className="container px-32 mx-auto">


### PR DESCRIPTION
- Fix advice image words
- Add shadow Small card
- Add shadow in Announcement detail card 
- Redesign search section in announcement-search

![screencapture-localhost-3000-academic-industry-announcements-2021-03-18-20_47_09](https://user-images.githubusercontent.com/35445297/111636515-26271980-882b-11eb-868a-c50baed9485a.png)

Related card
[🧡 [SP3] Redesign academic-industry feature](https://trello.com/c/SMlWI8jy)